### PR TITLE
[ObjectMapper] do not require mapping a target's required promoted property when not on source

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -110,7 +110,7 @@ final class ObjectMapper implements ObjectMapperInterface
         }
 
         $readMetadataFrom = $source;
-        $refl = $this->getSourceReflectionClass($source, $targetRefl);
+        $refl = $this->getSourceReflectionClass($source) ?? $targetRefl;
 
         // When source contains no metadata, we read metadata on the target instead
         if ($refl === $targetRefl) {
@@ -170,7 +170,7 @@ final class ObjectMapper implements ObjectMapperInterface
 
         if ($mappingToObject && $ctorArguments) {
             foreach ($ctorArguments as $property => $value) {
-                if ($targetRefl->hasProperty($property) && $targetRefl->getProperty($property)->isPublic()) {
+                if ($this->propertyIsMappable($refl, $property) && $this->propertyIsMappable($targetRefl, $property)) {
                     $mapToProperties[$property] = $value;
                 }
             }
@@ -314,11 +314,9 @@ final class ObjectMapper implements ObjectMapperInterface
     }
 
     /**
-     * @param \ReflectionClass<object> $targetRefl
-     *
-     * @return \ReflectionClass<object|T>
+     * @return ?\ReflectionClass<object|T>
      */
-    private function getSourceReflectionClass(object $source, \ReflectionClass $targetRefl): \ReflectionClass
+    private function getSourceReflectionClass(object $source): ?\ReflectionClass
     {
         $metadata = $this->metadataFactory->create($source);
         try {
@@ -343,6 +341,11 @@ final class ObjectMapper implements ObjectMapperInterface
             }
         }
 
-        return $targetRefl;
+        return null;
+    }
+
+    private function propertyIsMappable(\ReflectionClass $targetRefl, int|string $property): bool
+    {
+        return $targetRefl->hasProperty($property) && $targetRefl->getProperty($property)->isPublic();
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Source.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructorWithMetadata;
+
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Map;
+
+#[Map(target: Target::class)]
+class Source
+{
+    public function __construct(
+        public int    $number,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Target.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructorWithMetadata;
+
+class Target
+{
+    public function __construct(
+        /**
+         * This promoted property is required but should not lead to an exception on the object mapping as instantiation
+         * happened earlier already.
+         */
+        public string $notOnSourceButRequired,
+        public int    $number,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -58,6 +58,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Target as PromotedConstructorTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructorWithMetadata\Source as PromotedConstructorWithMetadataSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructorWithMetadata\Target as PromotedConstructorWithMetadataTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\AB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\Dto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\A as ServiceLocatorA;
@@ -364,6 +366,20 @@ final class ObjectMapperTest extends TestCase
         $b = new PromotedConstructorTarget(1, 'bar');
         $v = $mapper->map($a, $b);
         $this->assertSame($v->name, 'foo');
+    }
+
+    /**
+     * @dataProvider objectMapperProvider
+     */
+    public function testUpdateMappedObjectWithAdditionalConstructorPromotedProperties(ObjectMapperInterface $mapper)
+    {
+        $a = new PromotedConstructorWithMetadataSource(3, 'foo-will-get-updated');
+        $b = new PromotedConstructorWithMetadataTarget('notOnSourceButRequired', 1, 'bar');
+
+        $v = $mapper->map($a, $b);
+
+        $this->assertSame($v->name, $a->name);
+        $this->assertSame($v->number, $a->number);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a regression that was introduced by https://github.com/symfony/symfony/pull/61151/files#diff-f159a30ba80133f23e1d36531531f6af7a6ce4ae11aae49480d95e6895d6010cR159-R165 for ObjectMapper that was released on 7.3.2 related to "too eagerly" mapping a constructor's promoted property, without checking whether source actually requires mapping that property. Before 7.3.2 the promoted properties were not checked at all and thus were ignored.

## What changed

* Added test case where `target` has a required promoted property, which was set already and thus should not be written when not on `source`.
* Simplified the responsibility and lowered complexity of `getSourceReflectionClass`, to solely get the reflection class of the source. Made falling back to the `targetRefl` instance the responsibility of the callee.

## Side note

* Could also point this PR to symfony/7.3 directly?
* While debugging, it is quite hard to understand what all local variables in the `map` method do, especially as in situations where `source` does not have any mapping metadata set the target's reflection class gets used. Given the component still is marked experimental; what about extracting several key methods and naming them to what they do?